### PR TITLE
docs: clarify local validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,3 +304,5 @@ This pipeline covers automated validation, Kubernetes deployments with gated pro
 ## **License**
 This project is licensed under the MIT License.
 # trigger linguist refresh
+
+Note: Local validation works without extra setup.


### PR DESCRIPTION
Adds a note now that Zabbix template exists.