### PR TITLE
revert: re-include demo-api in language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -32,4 +32,3 @@ ansible/collections/** linguist-vendored
 docs/** linguist-documentation
 ansible/collections/** linguist-vendored
 docs/** linguist-documentation
-demo-api/** linguist-vendored


### PR DESCRIPTION
Restore previous GitHub Linguist mix (JS/Go visible again).