### PR TITLE
docs: add CI lint badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Lint](https://github.com/joycemwangi/automation-pipeline-challenge-c3/actions/workflows/lint.yml/badge.svg?branch=main)](https://github.com/joycemwangi/automation-pipeline-challenge-c3/actions/workflows/lint.yml)
+
 # **Automation Pipeline Challenge C3**
 
 <p align="center">


### PR DESCRIPTION
Shows current lint status from GitHub Actions.